### PR TITLE
feat: persist theme on page load

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -3,7 +3,7 @@ import React from 'react'
 import Toggle from '../common/Toggle'
 import Logo from '../Logo'
 import useStyles from './Header.styles'
-function Header(props) {
+function Header({ onChange, theme }) {
   const classes = useStyles()
   return (
     <AppBar position='static'>
@@ -24,7 +24,7 @@ function Header(props) {
             </span>
           </a>
         </Typography>
-        <Toggle onChange={props.onChange} />
+        <Toggle onChange={onChange} checked={theme === 'dark' ? true : false} />
       </Toolbar>
     </AppBar>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import CssBaseline from '@material-ui/core/CssBaseline'
 import { ThemeProvider } from '@material-ui/core/styles'
 import { Helmet } from 'react-helmet'
 import { darkTheme, lightTheme } from '../config/theme'
+import { useThemeState } from '../utils'
 import Header from '../components/Header'
 import icon from '../static/Icon.png'
 import Footer from '../components/Footer'
@@ -12,9 +13,9 @@ import Content from '../components/Content'
 
 export default function Home(props) {
   const classes = useStyles()
-  const [theme, setTheme] = React.useState(false)
+  const [theme, setTheme] = useThemeState('light', 'theme')
   return (
-    <ThemeProvider theme={theme ? darkTheme : lightTheme}>
+    <ThemeProvider theme={theme === 'dark' ? darkTheme : lightTheme}>
       <React.Fragment>
         <CssBaseline />
         <Helmet>
@@ -28,8 +29,9 @@ export default function Home(props) {
         </Helmet>
         <Header
           onChange={() => {
-            setTheme((prev) => !prev)
+            setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
           }}
+          theme={theme}
         />
         <Content {...props} />
         <footer className={classes.footer}>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const useThemeState = (defaultValue, key) => {
+  const [value, setValue] = React.useState(() => {
+    const theme = window.localStorage.getItem(key)
+
+    return theme !== null ? JSON.parse(theme) : defaultValue
+  })
+
+  React.useEffect(() => {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  }, [key, value])
+
+  return [value, setValue]
+}
+
+export { useThemeState }


### PR DESCRIPTION
#### Custom Hook for the theme change that will update the theme globally by adding it to the localStorage.

> This will help us to persist the selected theme in local storage and use it every time the page is refreshed.

**Here is the code for custom React hook:**

```
  const useThemeState = (defaultValue, key) => {
  const [value, setValue] = React.useState(() => {
    const theme = window.localStorage.getItem(key)

    return theme !== null ? JSON.parse(theme) : defaultValue
  })

  React.useEffect(() => {
    window.localStorage.setItem(key, JSON.stringify(value))
  }, [key, value])

  return [value, setValue]
}
```