### PR TITLE
Changed `tabler-icons` package to `@tabler/icons`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^16.14.0",
     "react-helmet": "^6.1.0",
     "simplebar-react": "^2.3.0",
-    "tabler-icons": "^1.35.0"
+    "@tabler/icons": "^1.35.0"
   },
   "devDependencies": {
     "prettier": "2.1.2"


### PR DESCRIPTION
Hi! We moved `tabler-icons` package to `@tabler` scope in npm. Old package will be deprecated soon. 

Thank you for your work! :) 